### PR TITLE
Set IdSSLIOHandlerSocketOpenSSL.PassThrough to False in order to supp…

### DIFF
--- a/IndySSL/Indy10SSLExample/sslClient10Main.pas
+++ b/IndySSL/Indy10SSLExample/sslClient10Main.pas
@@ -85,6 +85,10 @@ procedure TForm1.btnConnectClick(Sender: TObject);
 var
   line: string;
 begin
+  //PassThrough needs to be set to False for the client to work with server's PassThrough behavior
+  //See : https://www.atozed.com/forums/thread-1320.html
+  IdSSLIOHandlerSocketOpenSSL.PassThrough := False;
+
   btnConnect.enabled:= false;
   IdTCPClient.Host:= edtHostAddr.text;
   try


### PR DESCRIPTION
…ort the server's PassThrough behavior